### PR TITLE
Added static Undo/Redo text editor + skapat UndoRedoManager.

### DIFF
--- a/App.cs
+++ b/App.cs
@@ -101,7 +101,12 @@ namespace Travel_Journal
                         await Task.Delay(1000);
                         return; // Avslutar Run() och programmet
                 }
+                //Testa UNDO/REDO TEXT EDITOR
+                TextEditor editor = new TextEditor("");//skapar ny text editor med tom text
+                editor.RunMenu();//kör Undo/Redo meny
+
             }
         }
+        
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -7,7 +7,7 @@ namespace Travel_Journal
         static async Task Main(string[] args)
         {
             Console.OutputEncoding = System.Text.Encoding.UTF8; // All text visas korrekt inklusive emojis
-            await App.Run();
+           await App.Run();
         }
     }
 }

--- a/TextEditor.cs
+++ b/TextEditor.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Travel_Journal
+{
+    public class TextEditor//en text editor verktyg som använder UndoRedoManager<string> och testar Undo/Redo med text
+    {
+        private readonly UndoRedoManager<string> _undo;//UndoRedo manager som hanterar string,
+                                                       //_undo används överallt i klassen för att göra Undo/Redo
+ 
+        public TextEditor(string initialText) //skapar konstruktor som körs direkt när man skriver ny text
+                                              //initialText-texten som editorn ska börja med(kan det vara tom text med?)
+        {
+            _undo = new UndoRedoManager<string>(initialText); //// Skapar en ny UndoRedoManager för string och
+                                                              //skickar in initialText som första state.
+        }
+        public void RunMenu()//skapar metod som startar och kör text-editorn i konsolmeny
+        {
+            bool isRunning = true; // Flagga som styr om menyn ska fortsätta köras eller avslutas.
+
+            while (isRunning)// Meny-loop – kör så länge isRunning är true.
+            {
+                Console.Clear();//rensa konsolen så att innehållet blir snyggt
+
+                //Skriver ut Titel för editorn
+                Console.WriteLine("Text Editor med Undo/Redo");
+                Console.WriteLine();
+
+                //Visa nuvarande text från UndoRedoManager
+                Console.WriteLine("Aktuell Text:");
+                Console.WriteLine(_undo.CurrentState);
+                Console.WriteLine();
+
+                //Skriver ut menyval
+                Console.WriteLine("1.Skriv ny text:");
+                Console.WriteLine("2.Undo(ångra)");
+                Console.WriteLine("3.Redo(gör om)");
+                Console.WriteLine("0.Avsluta");
+                Console.WriteLine("Välj ett ålternativ(1-0): ");
+
+                string choice = Console.ReadLine();//läs in användarens val(den nya texten)
+
+                switch (choice)//hantera de olika val
+                {
+                    case "1"://Alternativ 1: Ny text skrivs
+                        Console.WriteLine("Skriv ny text");
+                        string newText = Console.ReadLine()!;
+                        _undo.ApplyChange(newText);//ny ändring
+                        break;
+
+                    case "2":// Kontrollera om Undo är möjligt.
+                        if (_undo.IsUndo)
+                        {
+
+
+                            _undo.Undo();// Utför Undo.
+                            Console.WriteLine("Ångrade senaste ändringen");// Meddela användaren.
+                        }
+                        else
+                        {
+                            Console.WriteLine($"Finns inget att ångra");// Om inget Undo finns, visa meddelande
+                        }
+                        Pause();
+                        break;
+
+                    case "3":// Alternativ 3: Redo
+                        if (_undo.IsRedo)// Kontrollera om Redo är möjligt.
+                        {
+                            _undo.Redo();// Utför Redo.
+                            Console.WriteLine("Gjorde om senaste ångringen");// Meddela användaren
+                        }
+                        else
+                        {
+                            Console.WriteLine("Finns inget att göra om");// Om inget Redo finns.
+                        }
+                        Pause();
+                        break;
+
+                    case "0":  // Avsluta loopen genom att sätta flaggan till false.
+                        isRunning = false;
+                        break;
+
+                        //Om användaren skriver något annat
+                    default:
+                        // Visa att valet är ogiltigt.
+                        Console.WriteLine("Ogiltigt val, försök igen.");
+
+                        // Vänta på tangenttryck innan menyn visas igen.
+                        Pause();
+                        break;
+
+                }
+
+
+            }
+        }
+        // Ny statisk metod som används i TripService
+        public static string EditTextWithUndo(string initialText)
+        {
+            var undo = new UndoRedoManager<string>(initialText);
+            bool isRunning = true;
+
+            while (isRunning)
+            {
+                Console.Clear();
+                Console.WriteLine("=== Edit Text with Undo/Redo ===");
+                Console.WriteLine();
+                Console.WriteLine("Aktuell text:");
+                Console.WriteLine(undo.CurrentState);
+                Console.WriteLine();
+
+                Console.WriteLine("1. Skriv ny text");
+                Console.WriteLine("2. Undo (ångra)");
+                Console.WriteLine("3. Redo (gör om)");
+                Console.WriteLine("0. Spara och gå tillbaka");
+                Console.Write("Val: ");
+
+                string choice = Console.ReadLine()!;
+
+                switch (choice)
+                {
+                    case "1":
+                        Console.Write("Ny text: ");
+                        string newText = Console.ReadLine()!;
+                        undo.ApplyChange(newText);
+                        break;
+
+                    case "2":
+                        if (undo.IsUndo)
+                        {
+                            undo.Undo();
+                        }
+                        else
+                        {
+                            Console.WriteLine("Det finns inget att ångra.");
+                        }
+                        break;
+
+                    case "3":
+                        if (undo.IsRedo)
+                        {
+                            undo.Redo();
+                        }
+                        else
+                        {
+                            Console.WriteLine("Det finns inget att göra om.");
+                        }
+                        break;
+
+                    case "0":
+                        isRunning = false;
+                        break;
+
+                    default:
+                        Console.WriteLine("Ogiltigt val.");
+                        break;
+                }
+            }
+
+            return undo.CurrentState;
+        }
+        
+      
+       
+        private void Pause()// Hjälpmetod som pausar konsolen tills användaren trycker på en tangent.
+        {
+            Console.WriteLine();
+            Console.WriteLine("Tryck på valfri tagent för att fortsätta...");// Instruktion till användaren.
+            Console.ReadKey(true);// Väntar på ett knapptryck.
+        }
+    }
+}
+        
+
+
+    
+

--- a/Trip.cs
+++ b/Trip.cs
@@ -5,6 +5,10 @@ namespace Travel_Journal
 {
     public class Trip
     {
+        private decimal budget;
+        private object score;
+        private object value;
+
         public Guid Id { get; set; } = Guid.NewGuid();     // Unikt ID för varje resa
         public string Country { get; set; }                // Land
         public string City { get; set; }                   // Stad
@@ -21,5 +25,30 @@ namespace Travel_Journal
         // Hjälpegenskaper
         public bool IsUpcoming => StartDate > DateTime.Now;
         public bool IsCompleted => EndDate < DateTime.Now;
+
+        //  Tom konstruktor – behövs för:
+        //  JSON-serialisering
+        //  object initializer: new Trip { ... }
+        public Trip()
+        {
+        }
+        public  Trip(string country, string city, DateTime startDate, DateTime endDate, decimal budget, int numberOfPassengers, int score, string review)
+        {
+            Country = country;
+            City = city;
+            StartDate = startDate;
+            EndDate = endDate;
+            PlannedBudget = budget;
+            NumberOfPassengers = numberOfPassengers;
+            Score = score;
+            Review = review;
+        }
+
+      
     }
 }
+
+
+
+
+

--- a/TripDraft.cs
+++ b/TripDraft.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Travel_Journal
+{
+    public class TripDraft // Ett enkelt "utkast-objekt" som håller allt som kan ändras
+                          // i en upcoming trip när vi jobbar med Undo/Redo.
+    {
+        public string Country { get; set; }
+        public string City { get; set; }
+        public decimal Budget { get; set; }
+        public DateTime StartDate { get; set; }
+        public DateTime EndDate { get; set; }
+
+        // Konstruktor som fyller alla fält.
+        public TripDraft(string country, string city, decimal budget, DateTime startDate, DateTime endDate)
+        {
+            Country = country;
+            City = city;
+            Budget = budget;
+            StartDate = startDate;
+            EndDate = endDate;
+        }
+        
+
+
+
+
+    }
+}

--- a/UndoRedoManager.cs
+++ b/UndoRedoManager.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Travel_Journal
+{
+    public class UndoRedoManager<T>
+    {
+        private readonly Stack<T> _undoStack = new();//stack som sparar historiken bakåt
+        private readonly Stack<T> _redoStack = new();//stack som sparar historiken framåt
+        public T CurrentState { get; private set; } //det nuvarande läget-text
+
+        //Skapar konstruktor och skickar in ett start-state
+        public UndoRedoManager(T initialState)
+        {
+            CurrentState = initialState; //Aktuellt state sätts till startvärdet
+        }
+
+        //Kollar om Undo är möjligt
+        public bool IsUndo => _undoStack.Count > 0;
+
+        //Kollar om Redo är möjligt
+        public bool IsRedo => _redoStack.Count > 0;
+
+        public void ApplyChange(T newState)   // finns redan
+        {
+            _undoStack.Push(CurrentState);    // lägg nuvarande state i undo-stack
+            CurrentState = newState;          // uppdatera aktuell state
+            _redoStack.Clear();               // rensa redo-historik
+        }
+
+        public bool Undo()
+        {
+            if (_undoStack.Count == 0)
+                return false;
+
+            _redoStack.Push(CurrentState);
+            CurrentState = _undoStack.Pop();
+            return true;
+        }
+
+        public bool Redo()
+        {
+            if (_redoStack.Count == 0)
+                return false;
+
+            _undoStack.Push(CurrentState);
+            CurrentState = _redoStack.Pop();
+            return true;
+        }
+        
+
+        //  NY METOD
+       // public void SetState(T newState)
+       // {
+       //     ApplyChange(newState);            // återanvänd samma logik
+       // }
+
+       // public void ClearHistory()//skapar metod för att tömma historiken(om man vill börja om)
+       // {
+        //    _undoStack.Clear();
+        //    _redoStack.Clear();
+        //}
+    }
+}
+


### PR DESCRIPTION
För att göra användarupplevelsen bättre i Travel Journal har projektet fått stöd för Undo/Redo när användaren skriver in text. Det gör att användaren kan prova sig fram, ångra misstag och göra om ändringar utan att tappa sin tidigare text.

Undo/Redo – Översikt och Användning i Projektet

Logiken bygger på en generisk klass UndoRedoManager<T>.
Den hanterar all Undo/Redo-funktionalitet oavsett datatyp tack vare <T>.

**Två stackar används för historik:**
1. _undoStack – tidigare värden (för Undo)
2. _redoStack – återskapade värden (för Redo)

**State styrs av tydliga egenskaper och metoder:**
1. CanUndo / CanRedo avgör vad som är möjligt
2. ApplyChange, Undo, Redo, ClearHistory sköter alla ändringar av state

**En statisk hjälpfunktion i TextEditor gör Undo/Redo enkel att använda:**
EditTextWithUndo(string initialText) öppnar en liten texteditor där användaren kan skriva, ångra, göra om och spara.

**Undo/Redo används praktiskt i TripService:**
När användaren skriver in t.ex. land (“country”) kan hen först ge en grundtext och sedan justera den via Undo/Redo innan den sparas.

**Strukturen är avgränsad, återanvändbar och framtidssäker:**
UndoRedoManager fungerar just nu med string, men är redo att användas med fler datatyper och framtida funktioner som notes, description, eller andra fält där historik kan vara viktigt.